### PR TITLE
Fix linter errors

### DIFF
--- a/.validaterc
+++ b/.validaterc
@@ -1,0 +1,108 @@
+{
+  "shared": {
+    "operations": {
+      "no_operation_id": "error",
+      "operation_id_case_convention": [
+        "error",
+        "lower_camel_case"
+      ],
+      "no_summary": "warning",
+      "no_array_responses": "error",
+      "parameter_order": "warning",
+      "undefined_tag": "warning",
+      "unused_tag": "warning",
+      "operation_id_naming_convention": "warning"
+    },
+    "pagination": {
+      "pagination_style": "error"
+    },
+    "parameters": {
+      "no_parameter_description": "error",
+      "param_name_case_convention": [
+        "error",
+        "lower_camel_case"
+      ],
+      "invalid_type_format_pair": "error",
+      "content_type_parameter": "error",
+      "accept_type_parameter": "error",
+      "authorization_parameter": "warning",
+      "required_param_has_default": "warning"
+    },
+    "paths": {
+      "missing_path_parameter": "error",
+      "duplicate_path_parameter": "error",
+      "snake_case_only": "off",
+      "paths_case_convention": [
+        "warning",
+        "lower_camel_case"
+      ]
+    },
+    "responses": {
+      "inline_response_schema": "error"
+    },
+    "security_definitions": {
+      "unused_security_schemes": "warning",
+      "unused_security_scopes": "warning"
+    },
+    "security": {
+      "invalid_non_empty_security_array": "error"
+    },
+    "schemas": {
+      "invalid_type_format_pair": "warning",
+      "snake_case_only": "off",
+      "no_schema_description": "warning",
+      "no_property_description": "warning",
+      "description_mentions_json": "warning",
+      "array_of_arrays": "warning",
+      "inconsistent_property_type": "off",
+      "property_case_convention": [
+        "error",
+        "lower_camel_case"
+      ],
+      "property_case_collision": "error",
+      "enum_case_convention": [
+        "warning",
+        "lower_snake_case"
+      ],
+      "undefined_required_properties": "warning"
+    },
+    "walker": {
+      "no_empty_descriptions": "error",
+      "has_circular_references": "warning",
+      "$ref_siblings": "off",
+      "duplicate_sibling_description": "warning",
+      "incorrect_ref_pattern": "warning"
+    }
+  },
+  "swagger2": {
+    "operations": {
+      "no_consumes_for_put_or_post": "error",
+      "get_op_has_consumes": "warning",
+      "no_produces": "warning"
+    }
+  },
+  "oas3": {
+    "operations": {
+      "no_request_body_content": "error",
+      "no_request_body_name": "warning"
+    },
+    "parameters": {
+      "no_in_property": "error",
+      "invalid_in_property": "error",
+      "missing_schema_or_content": "error",
+      "has_schema_and_content": "error"
+    },
+    "responses": {
+      "no_response_codes": "error",
+      "no_success_response_codes": "warning",
+      "no_response_body": "warning",
+      "ibm_status_code_guidelines": "warning"
+    },
+    "schemas": {
+      "json_or_param_binary_string": "warning"
+    }
+  },
+  "spectral": {
+    "rules": {}
+  }
+}

--- a/openapi/components/responses/BadRequest.yaml
+++ b/openapi/components/responses/BadRequest.yaml
@@ -1,0 +1,5 @@
+description: Invalid request
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/Error.yaml

--- a/openapi/components/responses/Conflict.yaml
+++ b/openapi/components/responses/Conflict.yaml
@@ -1,0 +1,5 @@
+description: The request conflicts with current state of the target resource
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/Error.yaml

--- a/openapi/components/responses/NotFound.yaml
+++ b/openapi/components/responses/NotFound.yaml
@@ -1,0 +1,5 @@
+description: The specified resource was not found
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/Error.yaml

--- a/openapi/components/responses/Unauthorized.yaml
+++ b/openapi/components/responses/Unauthorized.yaml
@@ -1,0 +1,5 @@
+description: Unauthorized
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/Error.yaml

--- a/openapi/components/schemas/Challenge.yaml
+++ b/openapi/components/schemas/Challenge.yaml
@@ -39,7 +39,7 @@ properties:
     items:
       type: string
     minItems: 1
-    tags:
+    example:
       - "Machine Learning"
       - "Breast Cancer"
   grant:

--- a/openapi/components/schemas/Challenge.yaml
+++ b/openapi/components/schemas/Challenge.yaml
@@ -23,7 +23,7 @@ properties:
   url:
     description: The URL to the challenge website
     type: string
-    format: url
+    format: uri
     example: https://synapse.org/sample-challenge
   status:
     description: The status of challenge

--- a/openapi/components/schemas/Challenge.yaml
+++ b/openapi/components/schemas/Challenge.yaml
@@ -58,11 +58,11 @@ example:
   tags:
     - "Machine Learning"
   organizers:
-    - id: 1
+    - id: 507f1f77bcf86cd799439011
       firstName: John
       lastName: Smith
       email: john.smith@example.org
-    - id: 2
+    - id: 507f1f77bcf86cd799439016
       firstName: J
       lastName: Doe
       email: jane.doe@example.org

--- a/openapi/components/schemas/Challenge.yaml
+++ b/openapi/components/schemas/Challenge.yaml
@@ -53,7 +53,7 @@ example:
   name: Sample Challenge
   startDate: "2020-11-10"
   endDate: "2020-12-31"
-  website: www.rocc.com/challenges/CH1234567
+  website: https://rocc.org/challenges/CH1234567
   status: closed
   tags:
     - "Machine Learning"

--- a/openapi/components/schemas/Challenge.yaml
+++ b/openapi/components/schemas/Challenge.yaml
@@ -2,45 +2,53 @@ type: object
 description: A challenge
 properties:
   id:
-    description: Challenge ID
+    description: The ID of the challenge
     type: string
     readOnly: true
     example: 507f1f77bcf86cd799439011
   name:
-    description: Name of challenge
+    description: The challenge name
     type: string
+    example: Sample Challenge
   startDate:
-    description: Starting date (when submissions are accepted) in YYYY-MM-DD format
+    description: When the challenge started
     type: string
     format: date
+    example: "2020-11-10"
   endDate:
-    description: Ending date (when submissions are no longer accepted) in YYYY-MM-DD format
+    description: When the challenge ended
     type: string
     format: date
+    example: "2020-12-31"
   website:
-    description: URL to challenge website
+    description: The URL to the challenge website
     type: string
     format: url
+    example: https://synapse.org/sample-challenge
   status:
-    description: Current status of challenge
+    description: The status of challenge
     type: string
     enum:
       - upcoming
       - open
       - closed
+    example: open
   tags:
-    description: Domains/area of expertise, e.g. "Breast Cancer", "Machine Learning"
+    description: The tags associated to the challenge
     type: array
     items:
       type: string
     minItems: 1
+    tags:
+      - "Machine Learning"
+      - "Breast Cancer"
   grant:
-    description: Monetary/resources sponsorship for challenge
+    description: The grants supporting this challenge
     type: array
     items:
       $ref: Grant.yaml
   organizers:
-    description: Persons involved with the challenge, e.g. clinical leads, data providers, governance
+    description: The organizers of the challenge
     type: array
     items:
       $ref: Person.yaml
@@ -49,21 +57,3 @@ required:
   - startDate
   - endDate
   - status
-example:
-  id: CH1234567
-  name: Sample Challenge
-  startDate: "2020-11-10"
-  endDate: "2020-12-31"
-  website: https://rocc.org/challenges/CH1234567
-  status: closed
-  tags:
-    - "Machine Learning"
-  organizers:
-    - id: 507f1f77bcf86cd799439011
-      firstName: John
-      lastName: Smith
-      email: john.smith@example.org
-    - id: 507f1f77bcf86cd799439016
-      firstName: J
-      lastName: Doe
-      email: jane.doe@example.org

--- a/openapi/components/schemas/Challenge.yaml
+++ b/openapi/components/schemas/Challenge.yaml
@@ -5,6 +5,7 @@ properties:
     description: Challenge ID
     type: string
     readOnly: true
+    example: 507f1f77bcf86cd799439011
   name:
     description: Name of challenge
     type: string

--- a/openapi/components/schemas/Challenge.yaml
+++ b/openapi/components/schemas/Challenge.yaml
@@ -20,7 +20,7 @@ properties:
     type: string
     format: date
     example: "2020-12-31"
-  website:
+  url:
     description: The URL to the challenge website
     type: string
     format: url

--- a/openapi/components/schemas/Email.yaml
+++ b/openapi/components/schemas/Email.yaml
@@ -1,4 +1,4 @@
-description: User email address
+description: An email address
 type: string
-format: test
+format: email
 example: john.smith@example.com

--- a/openapi/components/schemas/Error.yaml
+++ b/openapi/components/schemas/Error.yaml
@@ -1,0 +1,19 @@
+type: object
+description: Problem details (tools.ietf.org/html/rfc7807)
+properties:
+  title:
+    type: string
+    description: A human readable documentation for the problem type
+  status:
+    type: integer
+    description: The HTTP status code
+  detail:
+    type: string
+    description: A human readable explanation specific to this occurrence of
+      the problem
+  type:
+    type: string
+    description: An absolute URI that identifies the problem type
+required:
+  - title
+  - status

--- a/openapi/components/schemas/Grant.yaml
+++ b/openapi/components/schemas/Grant.yaml
@@ -2,19 +2,25 @@ type: object
 description: Information about monetary resources for challenge
 properties:
   id:
+    description: The ID of the grant
     type: string
     readOnly: true
+    example: 507f1f77bcf86cd799439011
   name:
+    description: The grant name
     type: string
   description:
+    description: A description of the grant
     type: string
   sponsor:
     $ref: Organization.yaml
   amount:
+    description: The amount of the grant in USD
     type: integer
-    format: float
   url:
+    description: The URL to the grant
     type: string
+    format: uri
 required:
   - name
   - sponsor

--- a/openapi/components/schemas/Organization.yaml
+++ b/openapi/components/schemas/Organization.yaml
@@ -2,11 +2,18 @@ type: object
 description: Organization
 properties:
   id:
+    description: The ID of the organization
     type: string
     readOnly: true
+    example: 507f1f77bcf86cd799439011
   name:
+    description: The organization name
     type: string
+    example: Sage Bionetworks
   url:
+    description: The URL to the homepage of the organization
     type: string
+    format: uri
+    example: https://sagebionetworks.org/
 required:
   - name

--- a/openapi/components/schemas/Organization.yaml
+++ b/openapi/components/schemas/Organization.yaml
@@ -1,5 +1,5 @@
 type: object
-description: Organization
+description: An organization
 properties:
   id:
     description: The ID of the organization
@@ -17,3 +17,4 @@ properties:
     example: https://sagebionetworks.org/
 required:
   - name
+  - url

--- a/openapi/components/schemas/PageOfChallenges.yaml
+++ b/openapi/components/schemas/PageOfChallenges.yaml
@@ -1,0 +1,11 @@
+type: object
+description: A page of Challenges
+allOf:
+  - $ref: ResponsePageMetadata.yaml
+  - type: object
+    properties:
+      challenges:
+        description: An array of Challenges
+        type: array
+        items:
+          $ref: Challenge.yaml

--- a/openapi/components/schemas/Person.yaml
+++ b/openapi/components/schemas/Person.yaml
@@ -1,13 +1,18 @@
 type: object
+description: A person
 properties:
   id:
+    description: The ID of a person
     type: string
     readOnly: true
+    example: 507f1f77bcf86cd799439011
   firstName:
+    description: The first name of a person
     type: string
     minLength: 1
     example: John
   lastName:
+    description: The last name of a Person
     type: string
     minLength: 1
     example: Smith

--- a/openapi/components/schemas/ResponsePageMetadata.yaml
+++ b/openapi/components/schemas/ResponsePageMetadata.yaml
@@ -1,0 +1,21 @@
+type: object
+description: A page of results
+properties:
+  offset:
+    description: Index of the first result that must be returned
+    type: integer
+  limit:
+    description: Maximum number of results returned
+    type: integer
+  links:
+    description: Links to navigate to different pages of results
+    type: object
+    properties:
+      next:
+        description: Link to the next page of results
+        type: string
+        format: uri
+required:
+  - offset
+  - limit
+  - links

--- a/openapi/components/schemas/User.yaml
+++ b/openapi/components/schemas/User.yaml
@@ -35,11 +35,11 @@ required:
   - username
   - email
 example:
-  id: 1
+  id: 507f1f77bcf86cd799439011
   username: John78
   firstName: John
   lastName: Smith
   email: john.smith@example.com
   organizations:
-    - id: 1
+    - id: 507f1f77bcf86cd799439012
       name: Organization1

--- a/openapi/components/schemas/User.yaml
+++ b/openapi/components/schemas/User.yaml
@@ -1,45 +1,47 @@
 type: object
+description: A user of the API
 properties:
   id:
+    description: The ID of the user
     type: string
     readOnly: true
+    example: 507f1f77bcf86cd799439011
   username:
+    description: The username of the user
     type: string
     minLength: 4
+    example: John78
   password:
+    description: The password of the user
     type: string
     format: password
     minLength: 3
     writeOnly: true
   firstName:
-    description: User first name
+    description: The first name of the user
     type: string
     minLength: 1
+    example: John
   lastName:
-    description: User last name
+    description: The last name of the user
     type: string
     minLength: 1
+    example: Smith
   email:
     $ref: Email.yaml
   role:
+    description: The role of the user
     type: string
     enum:
       - user
       - admin
     default: user
+    example: user
   organizations:
+    description: The organizations the user belongs to
     type: array
     items:
       $ref: Organization.yaml
 required:
   - username
   - email
-example:
-  id: 507f1f77bcf86cd799439011
-  username: John78
-  firstName: John
-  lastName: Smith
-  email: john.smith@example.com
-  organizations:
-    - id: 507f1f77bcf86cd799439012
-      name: Organization1

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -23,18 +23,13 @@ tags:
   - name: User
     description: Operations about users
 servers:
-  - url: "{protocol}://rocc.org/{environment}/v1"
+  - url: "{protocol}://rocc.org/api/v1"
     variables:
       protocol:
         enum:
           - http
           - https
         default: https
-      environment:
-        enum:
-          - api
-          - api.dev
-        default: api.dev
 paths:
   /challenges:
     $ref: paths/challenges.yaml

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -17,19 +17,13 @@ info:
     # Introduction
 
     TBA
-
-# externalDocs:
-#   description: Find out how to create a GitHub repo for your OpenAPI definition.
-#   url: 'https://github.com/Rebilly/generator-openapi-repo'
-
 tags:
   - name: Challenge
-    description: Challenge operations
+    description: Operations about challenges
   - name: User
-    description: User operations
-
+    description: Operations about users
 servers:
-  - url: "{protocol}://rocc.com/{environment}/v1"
+  - url: "{protocol}://rocc.org/{environment}/v1"
     variables:
       protocol:
         enum:
@@ -38,31 +32,13 @@ servers:
         default: https
       environment:
         enum:
-          - api     # production
-          - api.dev # development
+          - api
+          - api.dev
         default: api.dev
-
 paths:
   /challenges:
     $ref: paths/challenges.yaml
   /challenges/{id}:
-    $ref: "paths/challenges@{id}.yaml"
+    $ref: paths/challenges@{id}.yaml
   /users/{username}:
-    $ref: "paths/users@{username}.yaml"
-# components:
-#   securitySchemes:
-#     main_auth:
-#       type: oauth2
-#       flows:
-#         implicit:
-#           authorizationUrl: 'http://example.com/api/oauth/dialog'
-#           scopes:
-#             'read:users': read users info
-#             'write:users': modify or remove users
-# api_key:
-#   type: apiKey
-#   in: header
-#   name: api_key
-# basic_auth:
-#   type: http
-#   scheme: basic
+    $ref: paths/users@{username}.yaml

--- a/openapi/paths/challenges.yaml
+++ b/openapi/paths/challenges.yaml
@@ -3,19 +3,13 @@ post:
     - Challenge
   summary: Adds a challenge
   description: This can only be done by a Challenge Organizer
-  operationId: "challenges.create"
+  operationId: "createChallenge"
   requestBody:
     required: true
     content:
       application/json:
         schema:
           $ref: ../components/schemas/Challenge.yaml
-        example:
-          id: CH1234567
-          name: Sample Challenge
-          startDate: "2020-11-10"
-          endDate: "2020-12-31"
-          status: open
   responses:
     "201":
       description: Challenge created

--- a/openapi/paths/challenges.yaml
+++ b/openapi/paths/challenges.yaml
@@ -1,9 +1,9 @@
 post:
   tags:
     - Challenge
-  summary: Adds a challenge
-  description: This can only be done by a Challenge Organizer
-  operationId: "createChallenge"
+  summary: Add a challenge
+  description: Adds a challenge
+  operationId: createChallenge
   requestBody:
     required: true
     content:
@@ -11,24 +11,50 @@ post:
         schema:
           $ref: ../components/schemas/Challenge.yaml
   responses:
-    "201":
-      description: Challenge created
-    "403":
-      description: Forbidden
-
-get:
-  tags:
-    - Challenge
-  summary: Lists all challenges
-  operationId: "challenges.read_all"
-  responses:
-    "200":
-      description: Success
+    '200':
       content:
         application/json:
           schema:
-            type: array
-            items:
-              $ref: ../components/schemas/Challenge.yaml
-    "404":
-      description: Request not available
+            $ref: ../components/schemas/Challenge.yaml
+      description: Success
+    '403':
+      $ref: ../components/responses/Unauthorized.yaml
+    '404':
+      $ref: ../components/responses/NotFound.yaml
+    '409':
+      $ref: ../components/responses/Conflict.yaml
+get:
+  tags:
+    - Challenge
+  summary: List all the challenges
+  description: Returns all the challenges
+  operationId: listChallenges
+  parameters:
+    - in: query
+      name: limit
+      description: Maximum number of results returned
+      required: false
+      schema:
+        type: integer
+        default: 10
+        minimum: 10
+        maximum: 100
+    - in: query
+      name: offset
+      description: Index of the first result that must be returned
+      required: false
+      schema:
+        type: integer
+        default: 0
+        minimum: 0
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/PageOfChallenges.yaml
+      description: Success
+    '403':
+      $ref: ../components/responses/Unauthorized.yaml
+    '404':
+      $ref: ../components/responses/NotFound.yaml

--- a/openapi/paths/challenges@{id}.yaml
+++ b/openapi/paths/challenges@{id}.yaml
@@ -9,7 +9,7 @@ get:
   tags:
     - Challenge
   summary: Get a challenge
-  description: Returns the challenge for a given ID
+  description: Returns the challenge specified
   operationId: getChallenge
   responses:
     '200':
@@ -18,34 +18,34 @@ get:
         application/json:
           schema:
             $ref: ../components/schemas/Challenge.yaml
-    '400':
-      description: Invalid challenge ID
-    '422':
-      description: Challenge not found
-put:
-  tags:
-    - Challenge
-  summary: Updates all details of a challenge
-  description: |
-    Updates all details of the given challenge ID.
-
-    This action can only be done by a Challenge Organizer.
-  operationId: updateChallenge
-  requestBody:
-    required: true
-    content:
-      application/json:
-        schema:
-          $ref: ../components/schemas/Challenge.yaml
-  responses:
-    '200':
-      description: OK
-    '400':
-      description: Invalid challenge ID
     '403':
-      description: Forbidden
-    '422':
-      description: Challenge not found
+      $ref: ../components/responses/Unauthorized.yaml
+    '404':
+      $ref: ../components/responses/NotFound.yaml
+# put:
+#   tags:
+#     - Challenge
+#   summary: Updates all details of a challenge
+#   description: |
+#     Updates all details of the given challenge ID.
+
+#     This action can only be done by a Challenge Organizer.
+#   operationId: updateChallenge
+#   requestBody:
+#     required: true
+#     content:
+#       application/json:
+#         schema:
+#           $ref: ../components/schemas/Challenge.yaml
+#   responses:
+#     '200':
+#       description: OK
+#     '400':
+#       description: Invalid challenge ID
+#     '403':
+#       description: Forbidden
+#     '422':
+#       description: Challenge not found
 # patch:
 #   tags:
 #     - Challenge
@@ -74,18 +74,17 @@ put:
 delete:
   tags:
     - Challenge
-  summary: Removes a challenge
-  description: |
-    Removes the challenge of the given ID
-
-    This action can only be done by a Challenge Organizer.
+  summary: Delete a challenge
+  description: Deletes the challenge specified
   operationId: deleteChallenge
   responses:
-    '204':
-      description: Challenge removed
-    '400':
-      description: Invalid challenge ID
+    '200':
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/Challenge.yaml
     '403':
-      description: Forbidden
-    '422':
-      description: Challenge not found
+      $ref: ../components/responses/Unauthorized.yaml
+    '404':
+      $ref: ../components/responses/NotFound.yaml

--- a/openapi/paths/challenges@{id}.yaml
+++ b/openapi/paths/challenges@{id}.yaml
@@ -1,30 +1,27 @@
-# Parameter(s) used by all operations of this path
 parameters:
   - name: id
     in: path
-    description: challenge ID
+    description: The ID of the challenge
     required: true
     schema:
       type: string
-
 get:
   tags:
     - Challenge
-  summary: Lists one challenge
+  summary: Get a challenge
   description: Returns the challenge for a given ID
-  operationId: "challenges.read"
+  operationId: getChallenge
   responses:
-    "200":
+    '200':
       description: Success
       content:
         application/json:
           schema:
             $ref: ../components/schemas/Challenge.yaml
-    "400":
+    '400':
       description: Invalid challenge ID
-    "422":
+    '422':
       description: Challenge not found
-
 put:
   tags:
     - Challenge
@@ -33,7 +30,7 @@ put:
     Updates all details of the given challenge ID.
 
     This action can only be done by a Challenge Organizer.
-  operationId: "challenges.update_all"
+  operationId: updateChallenge
   requestBody:
     required: true
     content:
@@ -41,24 +38,23 @@ put:
         schema:
           $ref: ../components/schemas/Challenge.yaml
   responses:
-    "200":
+    '200':
       description: OK
-    "400":
+    '400':
       description: Invalid challenge ID
-    "403":
+    '403':
       description: Forbidden
-    "422":
+    '422':
       description: Challenge not found
+# patch:
+#   tags:
+#     - Challenge
+#   summary: Updates selected details of a challenge
+#   description: |
+#     Updates and/or adds one or more details of the given challenge ID.
 
-patch:
-  tags:
-    - Challenge
-  summary: Updates selected details of a challenge
-  description: |
-    Updates and/or adds one or more details of the given challenge ID.
-
-    This action can only be done by a Challenge Organizer.
-  operationId: "challenges.update"
+#     This action can only be done by a Challenge Organizer.
+#   operationId: "challenges.update"
   # TODO: add requestBody for PATCH request
   # requestBody:
   #   required: true
@@ -66,16 +62,15 @@ patch:
   #     application/json:
   #       schema:
   #         $ref: ../components/schemas/Challenge.yaml
-  responses:
-    "200":
-      description: OK
-    "400":
-      description: Invalid challenge ID
-    "403":
-      description: Forbidden
-    "422":
-      description: Challenge not found
-
+  # responses:
+  #   "200":
+  #     description: OK
+  #   "400":
+  #     description: Invalid challenge ID
+  #   "403":
+  #     description: Forbidden
+  #   "422":
+  #     description: Challenge not found
 delete:
   tags:
     - Challenge
@@ -84,13 +79,13 @@ delete:
     Removes the challenge of the given ID
 
     This action can only be done by a Challenge Organizer.
-  operationId: "challenges.delete"
+  operationId: deleteChallenge
   responses:
-    "204":
+    '204':
       description: Challenge removed
-    "400":
+    '400':
       description: Invalid challenge ID
-    "403":
+    '403':
       description: Forbidden
-    "422":
+    '422':
       description: Challenge not found

--- a/openapi/paths/users@{username}.yaml
+++ b/openapi/paths/users@{username}.yaml
@@ -1,29 +1,16 @@
-parameters:
-  - name: pretty_print
-    in: query
-    description: Pretty print response
-    schema:
-      type: boolean
 get:
   tags:
     - User
   summary: Get user by user name
-  description: |
-    Some description of the operation.
-    You can use `markdown` here.
+  description: Gets the user with the specified name
   operationId: getUserByName
   parameters:
     - name: username
       in: path
-      description: The name that needs to be fetched
+      description: The username of the user who needs to be fetched
       required: true
       schema:
         type: string
-    - name: with_email
-      in: query
-      description: Filter users without email
-      schema:
-        type: boolean
   responses:
     '200':
       description: Success
@@ -31,37 +18,33 @@ get:
         application/json:
           schema:
             $ref: ../components/schemas/User.yaml
-          example:
-            username: user1
-            email: user@example.com
     '403':
-      description: Forbidden
+      $ref: ../components/responses/Unauthorized.yaml
     '404':
-      description: User not found
-put:
-  tags:
-    - User
-  summary: Updated user
-  description: This can only be done by the logged in user.
-  operationId: updateUser
-  parameters:
-    - name: username
-      in: path
-      description: The name that needs to be updated
-      required: true
-      schema:
-        type: string
-  responses:
-    '200':
-      description: OK
-    '400':
-      description: Invalid user supplied
-    '404':
-      description: User not found
-  requestBody:
-    content:
-      application/json:
-        schema:
-          $ref: ../components/schemas/User.yaml
-    description: Updated user object
-    required: true
+      $ref: ../components/responses/NotFound.yaml
+# put:
+#   tags:
+#     - User
+#   summary: Update user
+#   description: Updates the details of the specified user
+#   operationId: updateUser
+#   parameters:
+#     - name: username
+#       in: path
+#       description: The username that needs to be updated
+#       required: true
+#       schema:
+#         type: string
+#   responses:
+#     '200':
+#       description: OK
+#     '400':
+#       description: Invalid user supplied
+#     '404':
+#       description: User not found
+#   requestBody:
+#     content:
+#       application/json:
+#         schema:
+#           $ref: ../components/schemas/User.yaml
+#     description: Updated user object

--- a/openapi/paths/users@{username}.yaml
+++ b/openapi/paths/users@{username}.yaml
@@ -24,12 +24,8 @@ get:
       description: Filter users without email
       schema:
         type: boolean
-  # security:
-  #   - main_auth:
-  #       - 'read:users'
-  #   - api_key: []
   responses:
-    "200":
+    '200':
       description: Success
       content:
         application/json:
@@ -38,9 +34,9 @@ get:
           example:
             username: user1
             email: user@example.com
-    "403":
+    '403':
       description: Forbidden
-    "404":
+    '404':
       description: User not found
 put:
   tags:
@@ -55,22 +51,16 @@ put:
       required: true
       schema:
         type: string
-  # security:
-  #   - main_auth:
-  #       - 'write:users'
   responses:
-    "200":
+    '200':
       description: OK
-    "400":
+    '400':
       description: Invalid user supplied
-    "404":
+    '404':
       description: User not found
   requestBody:
     content:
       application/json:
-        schema:
-          $ref: ../components/schemas/User.yaml
-      application/xml:
         schema:
           $ref: ../components/schemas/User.yaml
     description: Updated user object


### PR DESCRIPTION
@vpchung This PR adds IBM OpenAPI Validator and fixes all the issues it raises. This validator is added to enforce OpenAPI standards and an opinionated design of APIs adopted in related services that we develop at Sage (NLP Sandbox, Tool Registry).

In order to simplify the codebase, I commented out put and patch methods. We can already go a long way with add/get/list/delete operations. We can then add these operations later once you are familiar working with this API service.