### PR TITLE
add `nSubmissions` to ChallengeResults schema

### DIFF
--- a/openapi/components/schemas/ChallengeResults.yaml
+++ b/openapi/components/schemas/ChallengeResults.yaml
@@ -1,6 +1,10 @@
 type: object
 description: The results of a challenge
 properties:
+  nSubmissions:
+    description: Number of total submissions throughout the challenge
+    type: integer
+    minimum: 0
   nFinalSubmissions:
     description: Number of final submissions
     type: integer


### PR DESCRIPTION
With this PR:
* adding another submissions property to the ChallengeResults schema

I misspoke before -- the submission numbers in the MIAC-schematized spreadsheet is actually the number of submissions throughout the challenge, not just the final submissions (though there are some of those numbers in the landscape).