### PR TITLE
Update status codes

### DIFF
--- a/openapi/components/responses/Success.yaml
+++ b/openapi/components/responses/Success.yaml
@@ -1,0 +1,5 @@
+description: Successful operation
+content:
+  application/json:
+    schema:
+      type: object

--- a/openapi/components/responses/Success.yaml
+++ b/openapi/components/responses/Success.yaml
@@ -2,4 +2,4 @@ description: Successful operation
 content:
   application/json:
     schema:
-      type: object
+      $ref: ../schemas/EmptyObject.yaml

--- a/openapi/components/schemas/EmptyObject.yaml
+++ b/openapi/components/schemas/EmptyObject.yaml
@@ -1,0 +1,2 @@
+type: object
+description: Empty JSON object

--- a/openapi/paths/challenges.yaml
+++ b/openapi/paths/challenges.yaml
@@ -11,17 +11,17 @@ post:
         schema:
           $ref: ../components/schemas/Challenge.yaml
   responses:
-    '201':
+    "201":
       content:
         application/json:
           schema:
             $ref: ../components/schemas/ChallengeId.yaml
       description: Success
-    '400':
+    "400":
       $ref: ../components/responses/BadRequest.yaml
-    '404':
+    "404":
       $ref: ../components/responses/NotFound.yaml
-    '409':
+    "409":
       $ref: ../components/responses/Conflict.yaml
 get:
   tags:
@@ -56,13 +56,11 @@ get:
       style: deepObject
       explode: true
   responses:
-    '200':
+    "200":
       content:
         application/json:
           schema:
             $ref: ../components/schemas/PageOfChallenges.yaml
       description: Success
-    '400':
+    "400":
       $ref: ../components/responses/BadRequest.yaml
-    '404':
-      $ref: ../components/responses/NotFound.yaml

--- a/openapi/paths/challenges.yaml
+++ b/openapi/paths/challenges.yaml
@@ -19,8 +19,6 @@ post:
       description: Success
     "400":
       $ref: ../components/responses/BadRequest.yaml
-    "404":
-      $ref: ../components/responses/NotFound.yaml
     "409":
       $ref: ../components/responses/Conflict.yaml
 get:

--- a/openapi/paths/challenges.yaml
+++ b/openapi/paths/challenges.yaml
@@ -19,8 +19,6 @@ post:
       description: Success
     '400':
       $ref: ../components/responses/BadRequest.yaml
-    '403':
-      $ref: ../components/responses/Unauthorized.yaml
     '404':
       $ref: ../components/responses/NotFound.yaml
     '409':
@@ -66,7 +64,5 @@ get:
       description: Success
     '400':
       $ref: ../components/responses/BadRequest.yaml
-    '403':
-      $ref: ../components/responses/Unauthorized.yaml
     '404':
       $ref: ../components/responses/NotFound.yaml

--- a/openapi/paths/challenges.yaml
+++ b/openapi/paths/challenges.yaml
@@ -11,11 +11,11 @@ post:
         schema:
           $ref: ../components/schemas/Challenge.yaml
   responses:
-    '200':
+    '201':
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/Challenge.yaml
+            $ref: ../components/schemas/ChallengeId.yaml
       description: Success
     '400':
       $ref: ../components/responses/BadRequest.yaml

--- a/openapi/paths/challenges@{challengeId}.yaml
+++ b/openapi/paths/challenges@{challengeId}.yaml
@@ -18,8 +18,6 @@ get:
         application/json:
           schema:
             $ref: ../components/schemas/Challenge.yaml
-    "403":
-      $ref: ../components/responses/Unauthorized.yaml
     "404":
       $ref: ../components/responses/NotFound.yaml
 delete:
@@ -31,7 +29,5 @@ delete:
   responses:
     "200":
       $ref: ../components/responses/Success.yaml
-    "403":
-      $ref: ../components/responses/Unauthorized.yaml
     "404":
       $ref: ../components/responses/NotFound.yaml

--- a/openapi/paths/challenges@{challengeId}.yaml
+++ b/openapi/paths/challenges@{challengeId}.yaml
@@ -12,15 +12,15 @@ get:
   description: Returns the challenge specified
   operationId: getChallenge
   responses:
-    '200':
+    "200":
       description: Success
       content:
         application/json:
           schema:
             $ref: ../components/schemas/Challenge.yaml
-    '403':
+    "403":
       $ref: ../components/responses/Unauthorized.yaml
-    '404':
+    "404":
       $ref: ../components/responses/NotFound.yaml
 delete:
   tags:
@@ -29,13 +29,9 @@ delete:
   description: Deletes the challenge specified
   operationId: deleteChallenge
   responses:
-    '200':
-      description: Success
-      content:
-        application/json:
-          schema:
-            $ref: ../components/schemas/Challenge.yaml
-    '403':
+    "200":
+      $ref: ../components/responses/Success.yaml
+    "403":
       $ref: ../components/responses/Unauthorized.yaml
-    '404':
+    "404":
       $ref: ../components/responses/NotFound.yaml

--- a/openapi/paths/grants.yaml
+++ b/openapi/paths/grants.yaml
@@ -10,11 +10,11 @@ post:
         schema:
           $ref: ../components/schemas/Grant.yaml
   responses:
-    '200':
+    '201':
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/Grant.yaml
+            $ref: ../components/schemas/GrantId.yaml
       description: Success
     '403':
       $ref: ../components/responses/Unauthorized.yaml

--- a/openapi/paths/grants.yaml
+++ b/openapi/paths/grants.yaml
@@ -16,8 +16,6 @@ post:
           schema:
             $ref: ../components/schemas/GrantId.yaml
       description: Success
-    '403':
-      $ref: ../components/responses/Unauthorized.yaml
     '404':
       $ref: ../components/responses/NotFound.yaml
     '409':
@@ -53,8 +51,6 @@ get:
           schema:
             $ref: ../components/schemas/PageOfGrants.yaml
       description: Success
-    '403':
-      $ref: ../components/responses/Unauthorized.yaml
     '404':
       $ref: ../components/responses/NotFound.yaml
 

--- a/openapi/paths/grants.yaml
+++ b/openapi/paths/grants.yaml
@@ -10,15 +10,15 @@ post:
         schema:
           $ref: ../components/schemas/Grant.yaml
   responses:
-    '201':
+    "201":
       content:
         application/json:
           schema:
             $ref: ../components/schemas/GrantId.yaml
       description: Success
-    '404':
-      $ref: ../components/responses/NotFound.yaml
-    '409':
+    "400":
+      $ref: ../components/responses/BadRequest.yaml
+    "409":
       $ref: ../components/responses/Conflict.yaml
 get:
   tags:
@@ -45,12 +45,11 @@ get:
         default: 0
         minimum: 0
   responses:
-    '200':
+    "200":
       content:
         application/json:
           schema:
             $ref: ../components/schemas/PageOfGrants.yaml
       description: Success
-    '404':
-      $ref: ../components/responses/NotFound.yaml
-
+    "400":
+      $ref: ../components/responses/BadRequest.yaml

--- a/openapi/paths/grants@{grantId}.yaml
+++ b/openapi/paths/grants@{grantId}.yaml
@@ -12,15 +12,15 @@ get:
   description: Returns the grant specified
   operationId: getGrant
   responses:
-    '200':
+    "200":
       description: Success
       content:
         application/json:
           schema:
             $ref: ../components/schemas/Grant.yaml
-    '403':
+    "403":
       $ref: ../components/responses/Unauthorized.yaml
-    '404':
+    "404":
       $ref: ../components/responses/NotFound.yaml
 delete:
   tags:
@@ -29,13 +29,9 @@ delete:
   description: Deletes the grant specified
   operationId: deleteGrant
   responses:
-    '200':
-      description: Success
-      content:
-        application/json:
-          schema:
-            $ref: ../components/schemas/Grant.yaml
-    '403':
+    "200":
+      $ref: ../components/responses/Success.yaml
+    "403":
       $ref: ../components/responses/Unauthorized.yaml
-    '404':
+    "404":
       $ref: ../components/responses/NotFound.yaml

--- a/openapi/paths/grants@{grantId}.yaml
+++ b/openapi/paths/grants@{grantId}.yaml
@@ -18,8 +18,6 @@ get:
         application/json:
           schema:
             $ref: ../components/schemas/Grant.yaml
-    "403":
-      $ref: ../components/responses/Unauthorized.yaml
     "404":
       $ref: ../components/responses/NotFound.yaml
 delete:
@@ -31,7 +29,5 @@ delete:
   responses:
     "200":
       $ref: ../components/responses/Success.yaml
-    "403":
-      $ref: ../components/responses/Unauthorized.yaml
     "404":
       $ref: ../components/responses/NotFound.yaml

--- a/openapi/paths/organizations.yaml
+++ b/openapi/paths/organizations.yaml
@@ -17,11 +17,11 @@ post:
         schema:
           $ref: ../components/schemas/Organization.yaml
   responses:
-    '200':
+    '201':
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/Organization.yaml
+            $ref: ../components/schemas/OrganizationId.yaml
       description: Success
     '403':
       $ref: ../components/responses/Unauthorized.yaml

--- a/openapi/paths/organizations.yaml
+++ b/openapi/paths/organizations.yaml
@@ -23,8 +23,6 @@ post:
           schema:
             $ref: ../components/schemas/OrganizationId.yaml
       description: Success
-    '403':
-      $ref: ../components/responses/Unauthorized.yaml
     '404':
       $ref: ../components/responses/NotFound.yaml
     '409':
@@ -60,8 +58,6 @@ get:
           schema:
             $ref: ../components/schemas/PageOfOrganizations.yaml
       description: Success
-    '403':
-      $ref: ../components/responses/Unauthorized.yaml
     '404':
       $ref: ../components/responses/NotFound.yaml
 

--- a/openapi/paths/organizations.yaml
+++ b/openapi/paths/organizations.yaml
@@ -17,15 +17,15 @@ post:
         schema:
           $ref: ../components/schemas/Organization.yaml
   responses:
-    '201':
+    "201":
       content:
         application/json:
           schema:
             $ref: ../components/schemas/OrganizationId.yaml
       description: Success
-    '404':
-      $ref: ../components/responses/NotFound.yaml
-    '409':
+    "400":
+      $ref: ../components/responses/BadRequest.yaml
+    "409":
       $ref: ../components/responses/Conflict.yaml
 get:
   tags:
@@ -52,12 +52,11 @@ get:
         default: 0
         minimum: 0
   responses:
-    '200':
+    "200":
       content:
         application/json:
           schema:
             $ref: ../components/schemas/PageOfOrganizations.yaml
       description: Success
-    '404':
-      $ref: ../components/responses/NotFound.yaml
-
+    "400":
+      $ref: ../components/responses/BadRequest.yaml

--- a/openapi/paths/organizations@{organizationId}.yaml
+++ b/openapi/paths/organizations@{organizationId}.yaml
@@ -12,15 +12,15 @@ get:
   description: Returns the organization specified
   operationId: getOrganization
   responses:
-    '200':
+    "200":
       description: Success
       content:
         application/json:
           schema:
             $ref: ../components/schemas/Organization.yaml
-    '403':
+    "403":
       $ref: ../components/responses/Unauthorized.yaml
-    '404':
+    "404":
       $ref: ../components/responses/NotFound.yaml
 delete:
   tags:
@@ -29,13 +29,9 @@ delete:
   description: Deletes the organization specified
   operationId: deleteOrganization
   responses:
-    '200':
-      description: Success
-      content:
-        application/json:
-          schema:
-            $ref: ../components/schemas/Organization.yaml
-    '403':
+    "200":
+      $ref: ../components/responses/Success.yaml
+    "403":
       $ref: ../components/responses/Unauthorized.yaml
-    '404':
+    "404":
       $ref: ../components/responses/NotFound.yaml

--- a/openapi/paths/organizations@{organizationId}.yaml
+++ b/openapi/paths/organizations@{organizationId}.yaml
@@ -18,8 +18,6 @@ get:
         application/json:
           schema:
             $ref: ../components/schemas/Organization.yaml
-    "403":
-      $ref: ../components/responses/Unauthorized.yaml
     "404":
       $ref: ../components/responses/NotFound.yaml
 delete:
@@ -31,7 +29,5 @@ delete:
   responses:
     "200":
       $ref: ../components/responses/Success.yaml
-    "403":
-      $ref: ../components/responses/Unauthorized.yaml
     "404":
       $ref: ../components/responses/NotFound.yaml

--- a/openapi/paths/persons.yaml
+++ b/openapi/paths/persons.yaml
@@ -10,11 +10,11 @@ post:
         schema:
           $ref: ../components/schemas/Person.yaml
   responses:
-    '200':
+    '201':
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/Person.yaml
+            $ref: ../components/schemas/PersonId.yaml
       description: Success
     '400':
       $ref: ../components/responses/BadRequest.yaml

--- a/openapi/paths/persons.yaml
+++ b/openapi/paths/persons.yaml
@@ -10,17 +10,17 @@ post:
         schema:
           $ref: ../components/schemas/Person.yaml
   responses:
-    '201':
+    "201":
       content:
         application/json:
           schema:
             $ref: ../components/schemas/PersonId.yaml
       description: Success
-    '400':
+    "400":
       $ref: ../components/responses/BadRequest.yaml
-    '404':
+    "404":
       $ref: ../components/responses/NotFound.yaml
-    '409':
+    "409":
       $ref: ../components/responses/Conflict.yaml
 get:
   tags:
@@ -55,14 +55,11 @@ get:
       style: deepObject
       explode: true
   responses:
-    '200':
+    "200":
       content:
         application/json:
           schema:
             $ref: ../components/schemas/PageOfPersons.yaml
       description: Success
-    '400':
+    "400":
       $ref: ../components/responses/BadRequest.yaml
-    '404':
-      $ref: ../components/responses/NotFound.yaml
-

--- a/openapi/paths/persons.yaml
+++ b/openapi/paths/persons.yaml
@@ -18,8 +18,6 @@ post:
       description: Success
     "400":
       $ref: ../components/responses/BadRequest.yaml
-    "404":
-      $ref: ../components/responses/NotFound.yaml
     "409":
       $ref: ../components/responses/Conflict.yaml
 get:

--- a/openapi/paths/persons.yaml
+++ b/openapi/paths/persons.yaml
@@ -18,8 +18,6 @@ post:
       description: Success
     '400':
       $ref: ../components/responses/BadRequest.yaml
-    '403':
-      $ref: ../components/responses/Unauthorized.yaml
     '404':
       $ref: ../components/responses/NotFound.yaml
     '409':
@@ -65,8 +63,6 @@ get:
       description: Success
     '400':
       $ref: ../components/responses/BadRequest.yaml
-    '403':
-      $ref: ../components/responses/Unauthorized.yaml
     '404':
       $ref: ../components/responses/NotFound.yaml
 

--- a/openapi/paths/persons@{personId}.yaml
+++ b/openapi/paths/persons@{personId}.yaml
@@ -18,8 +18,6 @@ get:
         application/json:
           schema:
             $ref: ../components/schemas/Person.yaml
-    "403":
-      $ref: ../components/responses/Unauthorized.yaml
     "404":
       $ref: ../components/responses/NotFound.yaml
 delete:
@@ -31,7 +29,5 @@ delete:
   responses:
     "200":
       $ref: ../components/responses/Success.yaml
-    "403":
-      $ref: ../components/responses/Unauthorized.yaml
     "404":
       $ref: ../components/responses/NotFound.yaml

--- a/openapi/paths/persons@{personId}.yaml
+++ b/openapi/paths/persons@{personId}.yaml
@@ -12,15 +12,15 @@ get:
   description: Returns the person specified
   operationId: getPerson
   responses:
-    '200':
+    "200":
       description: Success
       content:
         application/json:
           schema:
             $ref: ../components/schemas/Person.yaml
-    '403':
+    "403":
       $ref: ../components/responses/Unauthorized.yaml
-    '404':
+    "404":
       $ref: ../components/responses/NotFound.yaml
 delete:
   tags:
@@ -29,13 +29,9 @@ delete:
   description: Deletes the person specified
   operationId: deletePerson
   responses:
-    '200':
-      description: Success
-      content:
-        application/json:
-          schema:
-            $ref: ../components/schemas/Person.yaml
-    '403':
+    "200":
+      $ref: ../components/responses/Success.yaml
+    "403":
       $ref: ../components/responses/Unauthorized.yaml
-    '404':
+    "404":
       $ref: ../components/responses/NotFound.yaml

--- a/openapi/paths/tags.yaml
+++ b/openapi/paths/tags.yaml
@@ -25,8 +25,6 @@ post:
       description: Success
     '400':
       $ref: ../components/responses/BadRequest.yaml
-    '403':
-      $ref: ../components/responses/Unauthorized.yaml
     '404':
       $ref: ../components/responses/NotFound.yaml
     '409':
@@ -70,8 +68,6 @@ get:
           schema:
             $ref: ../components/schemas/PageOfTags.yaml
       description: Success
-    '403':
-      $ref: ../components/responses/Unauthorized.yaml
     '404':
       $ref: ../components/responses/NotFound.yaml
 

--- a/openapi/paths/tags.yaml
+++ b/openapi/paths/tags.yaml
@@ -17,11 +17,11 @@ post:
         schema:
           $ref: ../components/schemas/Tag.yaml
   responses:
-    '200':
+    '201':
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/Tag.yaml
+            $ref: ../components/schemas/TagId.yaml
       description: Success
     '400':
       $ref: ../components/responses/BadRequest.yaml

--- a/openapi/paths/tags.yaml
+++ b/openapi/paths/tags.yaml
@@ -17,17 +17,15 @@ post:
         schema:
           $ref: ../components/schemas/Tag.yaml
   responses:
-    '201':
+    "201":
       content:
         application/json:
           schema:
             $ref: ../components/schemas/TagId.yaml
       description: Success
-    '400':
+    "400":
       $ref: ../components/responses/BadRequest.yaml
-    '404':
-      $ref: ../components/responses/NotFound.yaml
-    '409':
+    "409":
       $ref: ../components/responses/Conflict.yaml
 get:
   tags:
@@ -62,12 +60,11 @@ get:
       style: deepObject
       explode: true
   responses:
-    '200':
+    "200":
       content:
         application/json:
           schema:
             $ref: ../components/schemas/PageOfTags.yaml
       description: Success
-    '404':
-      $ref: ../components/responses/NotFound.yaml
-
+    "400":
+      $ref: ../components/responses/BadRequest.yaml

--- a/openapi/paths/tags@{tagId}.yaml
+++ b/openapi/paths/tags@{tagId}.yaml
@@ -18,8 +18,6 @@ get:
         application/json:
           schema:
             $ref: ../components/schemas/Tag.yaml
-    "403":
-      $ref: ../components/responses/Unauthorized.yaml
     "404":
       $ref: ../components/responses/NotFound.yaml
 delete:
@@ -31,7 +29,5 @@ delete:
   responses:
     "200":
       $ref: ../components/responses/Success.yaml
-    "403":
-      $ref: ../components/responses/Unauthorized.yaml
     "404":
       $ref: ../components/responses/NotFound.yaml

--- a/openapi/paths/tags@{tagId}.yaml
+++ b/openapi/paths/tags@{tagId}.yaml
@@ -12,15 +12,15 @@ get:
   description: Returns the tag specified
   operationId: getTag
   responses:
-    '200':
+    "200":
       description: Success
       content:
         application/json:
           schema:
             $ref: ../components/schemas/Tag.yaml
-    '403':
+    "403":
       $ref: ../components/responses/Unauthorized.yaml
-    '404':
+    "404":
       $ref: ../components/responses/NotFound.yaml
 delete:
   tags:
@@ -29,13 +29,9 @@ delete:
   description: Deletes the tag specified
   operationId: deleteTag
   responses:
-    '200':
-      description: Success
-      content:
-        application/json:
-          schema:
-            $ref: ../components/schemas/Tag.yaml
-    '403':
+    "200":
+      $ref: ../components/responses/Success.yaml
+    "403":
       $ref: ../components/responses/Unauthorized.yaml
-    '404':
+    "404":
       $ref: ../components/responses/NotFound.yaml


### PR DESCRIPTION
With this PR:

- when a POST operation is run, a status code of `201` is returned along with just the entity ID created (#43)
- when a DELETE operation is run, an empty JSON object is returned (#42)
- consolidate `4xx` status codes returned for POST operations (#51), e.g. `400` for invalid request bodies, ~~`404` for unknown query parameters,~~ `409` for values already found in database
- create new EmptyObject schema for empty JSON object