### PR TITLE
Make `email` property no longer required

### DIFF
--- a/openapi/components/schemas/PersonCreateRequest.yaml
+++ b/openapi/components/schemas/PersonCreateRequest.yaml
@@ -17,7 +17,6 @@ properties:
 required:
   - firstName
   - lastName
-  - email
 example:
   firstName: John
   lastName: Smith


### PR DESCRIPTION
Removing the `email` property as required from the `PersonCreateRequest` schema. I forgot that our current list of organizers in the DREAM Landscape does not have any information on their emails.

