### PR TITLE
replace 404 status code with 500

### DIFF
--- a/openapi/paths/healthCheck.yaml
+++ b/openapi/paths/healthCheck.yaml
@@ -11,5 +11,5 @@ get:
         application/json:
           schema:
             $ref: ../components/schemas/HealthCheck.yaml
-    '404':
-      $ref: ../components/responses/NotFound.yaml
+    '500':
+      $ref: ../components/responses/InternalServerError.yaml


### PR DESCRIPTION
With this PR:

* update the `404 Not Found` status code with `500 Internal Server Error`

In [rocc](https://github.com/Sage-Bionetworks/rocc/pull/70), I am returning the `200` and `500` status codes, not `200` and `404`, so this PR will address that in the healthCheck schema appropriately.