### PR TITLE
Add `links` to each 201 response

### DIFF
--- a/openapi/components/links/DeleteChallengeById.yaml
+++ b/openapi/components/links/DeleteChallengeById.yaml
@@ -1,0 +1,6 @@
+operationId: deleteChallenge
+description: >
+  The `id` value returned in the response can be used as the
+  `challengeId` parameter in `DELETE /challenges/{challengeId}`
+parameters:
+  challengeId: $response.body#/challengeId

--- a/openapi/components/links/DeleteGrantById.yaml
+++ b/openapi/components/links/DeleteGrantById.yaml
@@ -1,0 +1,6 @@
+operationId: deleteGrant
+description: >
+  The `id` value returned in the response can be used as the
+  `grantId` parameter in `DELETE /grants/{grantId}`
+parameters:
+  challengeId: $response.body#/grantId

--- a/openapi/components/links/DeleteGrantById.yaml
+++ b/openapi/components/links/DeleteGrantById.yaml
@@ -3,4 +3,4 @@ description: >
   The `id` value returned in the response can be used as the
   `grantId` parameter in `DELETE /grants/{grantId}`
 parameters:
-  challengeId: $response.body#/grantId
+  grantId: $response.body#/grantId

--- a/openapi/components/links/DeleteOrganizationById.yaml
+++ b/openapi/components/links/DeleteOrganizationById.yaml
@@ -1,0 +1,6 @@
+operationId: deleteOrganization
+description: >
+  The `id` value returned in the response can be used as the
+  `organizationId` parameter in `DELETE /organizations/{organizationId}`
+parameters:
+  challengeId: $response.body#/organizationId

--- a/openapi/components/links/DeleteOrganizationById.yaml
+++ b/openapi/components/links/DeleteOrganizationById.yaml
@@ -3,4 +3,4 @@ description: >
   The `id` value returned in the response can be used as the
   `organizationId` parameter in `DELETE /organizations/{organizationId}`
 parameters:
-  challengeId: $response.body#/organizationId
+  organizationId: $response.body#/organizationId

--- a/openapi/components/links/DeletePersonById.yaml
+++ b/openapi/components/links/DeletePersonById.yaml
@@ -1,0 +1,6 @@
+operationId: deletePerson
+description: >
+  The `id` value returned in the response can be used as the
+  `personId` parameter in `DELETE /persons/{personId}`
+parameters:
+  challengeId: $response.body#/personId

--- a/openapi/components/links/DeletePersonById.yaml
+++ b/openapi/components/links/DeletePersonById.yaml
@@ -3,4 +3,4 @@ description: >
   The `id` value returned in the response can be used as the
   `personId` parameter in `DELETE /persons/{personId}`
 parameters:
-  challengeId: $response.body#/personId
+  personId: $response.body#/personId

--- a/openapi/components/links/DeleteTagById.yaml
+++ b/openapi/components/links/DeleteTagById.yaml
@@ -3,4 +3,4 @@ description: >
   The `id` value returned in the response can be used as the
   `tagId` parameter in `DELETE /tags/{tagId}`
 parameters:
-  challengeId: $response.body#/tagId
+  tagId: $response.body#/tagId

--- a/openapi/components/links/DeleteTagById.yaml
+++ b/openapi/components/links/DeleteTagById.yaml
@@ -1,0 +1,6 @@
+operationId: deleteTag
+description: >
+  The `id` value returned in the response can be used as the
+  `tagId` parameter in `DELETE /tags/{tagId}`
+parameters:
+  challengeId: $response.body#/tagId

--- a/openapi/components/links/DeleteUserById.yaml
+++ b/openapi/components/links/DeleteUserById.yaml
@@ -1,0 +1,6 @@
+operationId: deleteUser
+description: >
+  The `username` value returned in the response can be used as the
+  `username` parameter in `DELETE /users/{username}`
+parameters:
+  challengeId: $response.body#/username

--- a/openapi/components/links/DeleteUserById.yaml
+++ b/openapi/components/links/DeleteUserById.yaml
@@ -3,4 +3,4 @@ description: >
   The `username` value returned in the response can be used as the
   `username` parameter in `DELETE /users/{username}`
 parameters:
-  challengeId: $response.body#/username
+  username: $response.body#/username

--- a/openapi/components/links/GetChallengeById.yaml
+++ b/openapi/components/links/GetChallengeById.yaml
@@ -1,0 +1,6 @@
+operationId: getChallenge
+description: >
+  The `id` value returned in the response can be used as the
+  `challengeId` parameter in `GET /challenges/{challengeId}`
+parameters:
+  challengeId: $response.body#/challengeId

--- a/openapi/components/links/GetGrantById.yaml
+++ b/openapi/components/links/GetGrantById.yaml
@@ -1,0 +1,6 @@
+operationId: getGrant
+description: >
+  The `id` value returned in the response can be used as the
+  `grantId` parameter in `GET /grants/{grantId}`
+parameters:
+  challengeId: $response.body#/grantId

--- a/openapi/components/links/GetGrantById.yaml
+++ b/openapi/components/links/GetGrantById.yaml
@@ -3,4 +3,4 @@ description: >
   The `id` value returned in the response can be used as the
   `grantId` parameter in `GET /grants/{grantId}`
 parameters:
-  challengeId: $response.body#/grantId
+  grantId: $response.body#/grantId

--- a/openapi/components/links/GetOrganizationById.yaml
+++ b/openapi/components/links/GetOrganizationById.yaml
@@ -1,0 +1,6 @@
+operationId: getOrganization
+description: >
+  The `id` value returned in the response can be used as the
+  `organizationId` parameter in `GET /organizations/{organizationId}`
+parameters:
+  challengeId: $response.body#/organizationId

--- a/openapi/components/links/GetOrganizationById.yaml
+++ b/openapi/components/links/GetOrganizationById.yaml
@@ -3,4 +3,4 @@ description: >
   The `id` value returned in the response can be used as the
   `organizationId` parameter in `GET /organizations/{organizationId}`
 parameters:
-  challengeId: $response.body#/organizationId
+  organizationId: $response.body#/organizationId

--- a/openapi/components/links/GetPersonById.yaml
+++ b/openapi/components/links/GetPersonById.yaml
@@ -3,4 +3,4 @@ description: >
   The `id` value returned in the response can be used as the
   `personId` parameter in `GET /persons/{personId}`
 parameters:
-  challengeId: $response.body#/personId
+  personId: $response.body#/personId

--- a/openapi/components/links/GetPersonById.yaml
+++ b/openapi/components/links/GetPersonById.yaml
@@ -1,0 +1,6 @@
+operationId: getPerson
+description: >
+  The `id` value returned in the response can be used as the
+  `personId` parameter in `GET /persons/{personId}`
+parameters:
+  challengeId: $response.body#/personId

--- a/openapi/components/links/GetTagById.yaml
+++ b/openapi/components/links/GetTagById.yaml
@@ -3,4 +3,4 @@ description: >
   The `id` value returned in the response can be used as the
   `tagId` parameter in `GET /tags/{tagId}`
 parameters:
-  challengeId: $response.body#/tagId
+  tagId: $response.body#/tagId

--- a/openapi/components/links/GetTagById.yaml
+++ b/openapi/components/links/GetTagById.yaml
@@ -1,0 +1,6 @@
+operationId: getTag
+description: >
+  The `id` value returned in the response can be used as the
+  `tagId` parameter in `GET /tags/{tagId}`
+parameters:
+  challengeId: $response.body#/tagId

--- a/openapi/components/links/GetUserById.yaml
+++ b/openapi/components/links/GetUserById.yaml
@@ -3,4 +3,4 @@ description: >
   The `username` value returned in the response can be used as the
   `username` parameter in `GET /users/{username}`
 parameters:
-  challengeId: $response.body#/username
+  username: $response.body#/username

--- a/openapi/components/links/GetUserById.yaml
+++ b/openapi/components/links/GetUserById.yaml
@@ -1,0 +1,6 @@
+operationId: getUser
+description: >
+  The `username` value returned in the response can be used as the
+  `username` parameter in `GET /users/{username}`
+parameters:
+  challengeId: $response.body#/username

--- a/openapi/components/schemas/ResponsePageMetadata.yaml
+++ b/openapi/components/schemas/ResponsePageMetadata.yaml
@@ -7,7 +7,7 @@ properties:
   limit:
     description: Maximum number of results returned
     type: integer
-  links:
+  paging:
     description: Links to navigate to different pages of results
     type: object
     properties:

--- a/openapi/components/schemas/ResponsePageMetadata.yaml
+++ b/openapi/components/schemas/ResponsePageMetadata.yaml
@@ -21,4 +21,4 @@ properties:
 required:
   - offset
   - limit
-  - links
+  - paging

--- a/openapi/paths/challenges.yaml
+++ b/openapi/paths/challenges.yaml
@@ -17,6 +17,11 @@ post:
           schema:
             $ref: ../components/schemas/ChallengeCreateResponse.yaml
       description: Success
+      links:
+        GetChallengeById:
+          $ref: ../components/links/GetChallengeById.yaml
+        DeleteChallengeById:
+          $ref: ../components/links/DeleteChallengeById.yaml
     '400':
       $ref: ../components/responses/BadRequest.yaml
     '409':

--- a/openapi/paths/grants.yaml
+++ b/openapi/paths/grants.yaml
@@ -16,6 +16,11 @@ post:
           schema:
             $ref: ../components/schemas/GrantCreateResponse.yaml
       description: Success
+      links:
+        GetGrantById:
+          $ref: ../components/links/GetGrantById.yaml
+        DeleteGrantById:
+          $ref: ../components/links/DeleteGrantById.yaml
     '400':
       $ref: ../components/responses/BadRequest.yaml
     '409':

--- a/openapi/paths/organizations.yaml
+++ b/openapi/paths/organizations.yaml
@@ -23,6 +23,11 @@ post:
           schema:
             $ref: ../components/schemas/OrganizationCreateResponse.yaml
       description: Success
+      links:
+        GetOrganizationById:
+          $ref: ../components/links/GetOrganizationById.yaml
+        DeleteOrganizationById:
+          $ref: ../components/links/DeleteOrganizationById.yaml
     '400':
       $ref: ../components/responses/BadRequest.yaml
     '409':

--- a/openapi/paths/persons.yaml
+++ b/openapi/paths/persons.yaml
@@ -16,6 +16,11 @@ post:
           schema:
             $ref: ../components/schemas/PersonCreateResponse.yaml
       description: Success
+      links:
+        GetPersonById:
+          $ref: ../components/links/GetPersonById.yaml
+        DeletePersonById:
+          $ref: ../components/links/DeletePersonById.yaml
     '400':
       $ref: ../components/responses/BadRequest.yaml
     '409':

--- a/openapi/paths/tags.yaml
+++ b/openapi/paths/tags.yaml
@@ -23,6 +23,11 @@ post:
           schema:
             $ref: ../components/schemas/TagCreateResponse.yaml
       description: Success
+      links:
+        GetTagById:
+          $ref: ../components/links/GetTagById.yaml
+        DeleteTagById:
+          $ref: ../components/links/DeleteTagById.yaml
     '400':
       $ref: ../components/responses/BadRequest.yaml
     '409':

--- a/openapi/paths/users.yaml
+++ b/openapi/paths/users.yaml
@@ -23,6 +23,11 @@ post:
           schema:
             $ref: ../components/schemas/UserCreateResponse.yaml
       description: Success
+      links:
+        GetUserById:
+          $ref: ../components/links/GetUserById.yaml
+        DeleteUserById:
+          $ref: ../components/links/DeleteUserById.yaml
     '400':
       $ref: ../components/responses/BadRequest.yaml
     '409':


### PR DESCRIPTION
With this PR:

* add `"links"` to each 201 POST operation; this will help expand the usage of the `*Id` response variable in the documentation (#49)
* create a schema for each target operation in `components/links/`, e.g. `GetChallengeById.yaml` for the `getChallenge` operation
* rename `links` property in ResponsePageMetadata to `paging` to remove possible name collision