### PR TITLE
Enable to sort challenges by createdAt and updatedAt

### DIFF
--- a/openapi/components/schemas/Challenge.yaml
+++ b/openapi/components/schemas/Challenge.yaml
@@ -16,6 +16,6 @@ allOf:
     required:
       - createdAt
       - updatedAt
-    example:
-      createdAt: '2017-07-08T16:18:44-04:00'
-      updatedAt: '2017-07-08T16:18:44-04:00'
+    # example:
+    #   createdAt: '2017-07-08T16:18:44-04:00'
+    #   updatedAt: '2017-07-08T16:18:44-04:00'

--- a/openapi/components/schemas/Challenge.yaml
+++ b/openapi/components/schemas/Challenge.yaml
@@ -10,7 +10,7 @@ allOf:
         type: string
         format: date-time
       updatedAt:
-        description: When this challenge has been created
+        description: When this challenge has last been updated
         type: string
         format: date-time
     required:

--- a/openapi/components/schemas/Challenge.yaml
+++ b/openapi/components/schemas/Challenge.yaml
@@ -3,3 +3,19 @@ description: A challenge
 allOf:
   - $ref: ChallengeCreateResponse.yaml
   - $ref: ChallengeCreateRequest.yaml
+  - type: object
+    properties:
+      createdAt:
+        description: When this challenge has been created
+        type: string
+        format: date-time
+      updatedAt:
+        description: When this challenge has been created
+        type: string
+        format: date-time
+    required:
+      - createdAt
+      - updatedAt
+    example:
+      createdAt: '2017-07-08T16:18:44-04:00'
+      updatedAt: '2017-07-08T16:18:44-04:00'

--- a/openapi/paths/challenges.yaml
+++ b/openapi/paths/challenges.yaml
@@ -35,8 +35,8 @@ get:
   description: Returns all the challenges
   operationId: listChallenges
   parameters:
-    - in: query
-      name: limit
+    - name: limit
+      in: query
       description: Maximum number of results returned
       required: false
       schema:
@@ -44,22 +44,39 @@ get:
         default: 10
         minimum: 10
         maximum: 100
-    - in: query
-      name: offset
+    - name: offset
+      in: query
       description: Index of the first result that must be returned
       required: false
       schema:
         type: integer
         default: 0
         minimum: 0
-    - in: query
-      name: filter
+    - name: filter
+      in: query
       description: Object that describes how to filter the results
       required: false
       schema:
         $ref: ../components/schemas/ChallengeFilter.yaml
       style: deepObject
       explode: true
+    - name: sort
+      in: query
+      required: false
+      schema:
+        type: string
+        enum:
+        - createdAt
+        - updatedAt
+    - name: direction
+      description: Can be either `asc` or `desc`. Ignored without `sort` parameter.
+      in: query
+      required: false
+      schema:
+        type: string
+        enum:
+        - asc
+        - desc
   responses:
     '200':
       content:

--- a/openapi/paths/challenges.yaml
+++ b/openapi/paths/challenges.yaml
@@ -62,6 +62,7 @@ get:
       explode: true
     - name: sort
       in: query
+      description: Property used to sort the results that must be returned
       required: false
       schema:
         type: string


### PR DESCRIPTION
Fixes #123 

### Notes

- In the challenge `list` path, I added two query parameters named `sort` and `direction` using the same parameter name and schema as in GitHub API. This information will be used by the API service to sort results before returning paginated responses.
- With this PR, I propose to swap the parameter properties `name` and `in` so that `name` comes first. This is because one is probably more interested in the parameter name, then the type of the parameter. This order is also more consistent with traditional schema where each property have their name on the first line. Example:

Before:

```
    - in: query
      name: limit
      description: Maximum number of results returned
      required: false
      schema:
        type: integer
        default: 10
        minimum: 10
        maximum: 100
```

After:

```
    - name: limit
      in: query
      description: Maximum number of results returned
      required: false
      schema:
        type: integer
        default: 10
        minimum: 10
        maximum: 100
```

If this proposal is accepted, this change will be propagated to all other path parameters in a separate PR.