### PR TITLE
DateRange.start and DateRange.end are no longer required

### DIFF
--- a/openapi/components/schemas/DateRange.yaml
+++ b/openapi/components/schemas/DateRange.yaml
@@ -8,9 +8,6 @@ properties:
     description: End date of the date range
     type: string
     format: date
-required:
-  - start
-  - end
 example:
   start: "2021-07-17"
   end: "2021-07-17"


### PR DESCRIPTION
The motivation is to allow DateRange with only the property `start` or `end` for filtering purpose.