### PR TITLE
Add Challenge.readmeId

### DIFF
--- a/openapi/components/schemas/Challenge.yaml
+++ b/openapi/components/schemas/Challenge.yaml
@@ -9,6 +9,8 @@ allOf:
         type: string
       ownerId:
         $ref: ../parameters/AccountId.yaml
+      readmeId:
+        $ref: ../parameters/ChallengeReadmeId.yaml
       createdAt:
         type: string
         format: date-time
@@ -18,6 +20,7 @@ allOf:
     required:
       - fullName
       - ownerId
+      - readmeId
       - createdAt
       - updatedAt
     example:


### PR DESCRIPTION
The motivation is to make the schema more transparent. The change allows a user who get a `Challenge` object to identify how to get the `ChallengeReadme` object. Before the change, the user would need to know that the collection `ChallengeReadme` exists first.