### PR TITLE
Add path to get registry info

### DIFF
--- a/openapi/components/schemas/Registry.yaml
+++ b/openapi/components/schemas/Registry.yaml
@@ -1,0 +1,25 @@
+type: object
+description: The Challenge Registry
+properties:
+  name:
+    type: string
+  description:
+    type: string
+  userCount:
+    type: integer
+  orgCount:
+    type: integer
+  challengeCount:
+    type: integer
+required:
+  - name
+  - description
+  - userCount
+  - orgCount
+  - challengeCount
+example:
+  name: Challenge Registry
+  description: A great challenge registry
+  userCount: 1000
+  orgCount: 1000
+  challengeCound: 1000

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -32,6 +32,8 @@ tags:
     description: Operations about organizations
   - name: OrgMembership
     description: Operations about org memberships
+  - name: Registry
+    description: Operations about the registry
   - name: Tag
     description: Operations about tags
   - name: User
@@ -89,6 +91,8 @@ paths:
     $ref: paths/orgMemberships.yaml
   /orgMemberships/{orgMembershipId}:
     $ref: paths/orgMemberships@{orgMembershipId}.yaml
+  /registry:
+    $ref: paths/registry.yaml
   /user:
     $ref: paths/user.yaml
   /user/starred:

--- a/openapi/paths/registry.yaml
+++ b/openapi/paths/registry.yaml
@@ -1,0 +1,15 @@
+get:
+  tags:
+    - Registry
+  summary: Get registry information
+  description: Get information about the registry
+  operationId: getRegistry
+  responses:
+    '200':
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/Registry.yaml
+    '500':
+      $ref: ../components/responses/InternalServerError.yaml


### PR DESCRIPTION
Addresses https://github.com/Sage-Bionetworks/rocc-app/issues/336.

## Notes

- Added the path `/registry` to get information about the challenge registry.
  - This information can be used on the home page
  - I plan to use this information with the Alexa skill
    - "Alexa, what is the challenge registry" => registry.description
    - "Alexa, how many challenges are registered?" => "There are {registry.challengeCount} registered."
