### PR TITLE
Update challenge filters

### DIFF
--- a/openapi/components/parameters/ChallengeInputDataType.yaml
+++ b/openapi/components/parameters/ChallengeInputDataType.yaml
@@ -1,8 +1,8 @@
-description: The challenge input data type
+description: A challenge input data type
 type: string
-enum:
-  - genomic
-  - clinical
+minLength: 3
+maxLength: 30
+pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$'
 example:
   - genomic
   - clinical

--- a/openapi/components/parameters/ChallengeInputDataType.yaml
+++ b/openapi/components/parameters/ChallengeInputDataType.yaml
@@ -1,8 +1,8 @@
-description: A challenge input data type
+description: The challenge input data type
 type: string
-minLength: 3
-maxLength: 30
-pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$'
+enum:
+  - genomic
+  - clinical
 example:
   - genomic
   - clinical

--- a/openapi/components/parameters/ChallengeInputDataType.yaml
+++ b/openapi/components/parameters/ChallengeInputDataType.yaml
@@ -1,4 +1,4 @@
-description: The Input Data Type
+description: A challenge input data type
 type: string
 minLength: 3
 maxLength: 30

--- a/openapi/components/schemas/Challenge.yaml
+++ b/openapi/components/schemas/Challenge.yaml
@@ -11,6 +11,22 @@ allOf:
         $ref: ../parameters/AccountId.yaml
       readmeId:
         $ref: ../parameters/ChallengeReadmeId.yaml
+      featured:
+        description: Whether the challenge is featured
+        type: boolean
+        default: false
+      participantCount:
+        description: Number of challenge participants
+        type: integer
+        default: 0
+      viewCount:
+        description: Number of challenge views
+        type: integer
+        default: 0
+      starredCount:
+        description: Number of times the challenge has been starred by users
+        type: integer
+        default: 0
       createdAt:
         type: string
         format: date-time

--- a/openapi/components/schemas/ChallengeCreateRequest.yaml
+++ b/openapi/components/schemas/ChallengeCreateRequest.yaml
@@ -49,7 +49,7 @@ properties:
   inputDataTypes:
     type: array
     items:
-      $ref: inputDataType.yaml
+      $ref: ../parameters/ChallengeInputDataType.yaml
     maxItems: 10
     nullable: true
   doi:

--- a/openapi/paths/challenges.yaml
+++ b/openapi/paths/challenges.yaml
@@ -40,15 +40,17 @@ get:
     - $ref: parameters/sort.yaml
     - $ref: parameters/direction.yaml
     - $ref: parameters/searchTerms.yaml
-    # - $ref: parameters/tagIds.yaml
     - $ref: parameters/topics.yaml
+    - $ref: parameters/inputDataTypes.yaml
+    - $ref: parameters/orgId.yaml
     - $ref: parameters/challenge/status.yaml
     - $ref: parameters/challenge/platformIds.yaml
     - $ref: parameters/challenge/difficulty.yaml
-    - $ref: parameters/inputDataTypes.yaml
     - $ref: parameters/challenge/submissionTypes.yaml
     - $ref: parameters/challenge/incentiveTypes.yaml
     - $ref: parameters/challenge/startDateRange.yaml
+    - $ref: parameters/challenge/organizerIds.yaml
+    - $ref: parameters/challenge/sponsorIds.yaml
   responses:
     '200':
       content:

--- a/openapi/paths/challenges.yaml
+++ b/openapi/paths/challenges.yaml
@@ -42,13 +42,13 @@ get:
     - $ref: parameters/searchTerms.yaml
     - $ref: parameters/topics.yaml
     - $ref: parameters/inputDataTypes.yaml
-    - $ref: parameters/orgId.yaml
     - $ref: parameters/challenge/status.yaml
     - $ref: parameters/challenge/platformIds.yaml
     - $ref: parameters/challenge/difficulty.yaml
     - $ref: parameters/challenge/submissionTypes.yaml
     - $ref: parameters/challenge/incentiveTypes.yaml
     - $ref: parameters/challenge/startDateRange.yaml
+    - $ref: parameters/challenge/orgIds.yaml
     - $ref: parameters/challenge/organizerIds.yaml
     - $ref: parameters/challenge/sponsorIds.yaml
   responses:

--- a/openapi/paths/parameters/challenge/orgIds.yaml
+++ b/openapi/paths/parameters/challenge/orgIds.yaml
@@ -1,0 +1,8 @@
+name: orgIds
+description: Array of organization ids used to filter the results
+in: query
+required: false
+schema:
+  type: array
+  items:
+    $ref: ../../../components/parameters/OrgId.yaml

--- a/openapi/paths/parameters/challenge/organizerIds.yaml
+++ b/openapi/paths/parameters/challenge/organizerIds.yaml
@@ -1,0 +1,8 @@
+name: organizerIds
+description: Array of organizer identifiers used to filter the results
+in: query
+required: false
+schema:
+  type: array
+  items:
+    $ref: ../../../components/parameters/UserId.yaml

--- a/openapi/paths/parameters/challenge/sponsorIds.yaml
+++ b/openapi/paths/parameters/challenge/sponsorIds.yaml
@@ -1,0 +1,8 @@
+name: sponsorIds
+description: Array of sponsor org identifiers used to filter the results
+in: query
+required: false
+schema:
+  type: array
+  items:
+    $ref: ../../../components/parameters/OrgId.yaml

--- a/openapi/paths/parameters/inputDataTypes.yaml
+++ b/openapi/paths/parameters/inputDataTypes.yaml
@@ -5,4 +5,4 @@ required: false
 schema:
   type: array
   items:
-    $ref: ../../components/schemas/inputDataType.yaml
+    $ref: ../../components/parameters/ChallengeInputDataType.yaml

--- a/openapi/paths/parameters/sort.yaml
+++ b/openapi/paths/parameters/sort.yaml
@@ -8,17 +8,17 @@ schema:
     - startDate
     - participantCount
     - viewCount
-    - favoriteCount
-    - alphabetical
+    - starredCount
+    - name
     - createdAt
     - updatedAt
 description: >
   Properties used to sort the results that must be returned:
     * featured - featured challenge, from featured to non-featured.
     * startDate - start date of a challenge, from latest to oldest.
-    * participantCount - number of participants of a challenge, from latest to oldest
-    * viewCount - number of views of a challenge, from latest to oldest
-    * favoriteCount - number of stargazers of a challenge, from latest to oldest
-    * alphabetical - name of a challenge, from A to Z
-    * createdAt - when a challenge is created, from latest to oldest
-    * updatedAt - when a challenge is updated, from latest to oldest
+    * participantCount - number of participants of a challenge, from most to least.
+    * viewCount - number of views of a challenge, from most to least.
+    * starredCount - number of stargazers of a challenge, from most to least.
+    * name - name of a challenge, from A to Z.
+    * createdAt - when a challenge is created, from latest to oldest.
+    * updatedAt - when a challenge is updated, from latest to oldest.


### PR DESCRIPTION
- [x] Move the input data type schemas to the folder `parameters`
- [x] Sorting option must match the name of challenge properties

```
  enum:
    - featured => TODO: Add Challenge.featured (boolean)
    - startDate
    - participantCount => TODO: Add Challenge.participantCount
    - viewCount => TODO: Add Challenge.viewCount
    - favoriteCount => TODO: Add Challenge.starredCount
    - alphabetical => TODO: replace by `name` as in `Challenge.name`
    - createdAt
    - updatedAt
 ```

- [x] Add challenge filters for:
  - orgs: list only challenges for org ID that are in the list specified
  - organizerIds: list only challenges that are organized by at least one organizers specified
  - sponsorIds: list only challenges that are supported by at least one of the sponsors specified