### PR TITLE
Add Oauth authentication to protect GET all users (demo)

### DIFF
--- a/openapi/components/securitySchemes/OAuth.yaml
+++ b/openapi/components/securitySchemes/OAuth.yaml
@@ -1,0 +1,8 @@
+type: oauth2
+description: For more information, see https://api.challenge-registry.org/docs/oauth
+flows:
+  implicit:
+    authorizationUrl: '/oauth2/authorize'
+    scopes:
+      read:users: read users info
+      write:users: modify or remove users

--- a/openapi/components/securitySchemes/main_auth.yaml
+++ b/openapi/components/securitySchemes/main_auth.yaml
@@ -1,7 +1,0 @@
-type: oauth2
-flows:
-  implicit:
-    authorizationUrl: 'http://example.com/api/oauth/dialog'
-    scopes:
-      'read:users': read users info
-      'write:users': modify or remove users

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -17,6 +17,7 @@ info:
     # Introduction
 
     TBA
+
 tags:
   - name: Account
     description: Operations about accounts
@@ -38,6 +39,7 @@ tags:
     description: Operations about users
   - name: HealthCheck
     description: Operations about health checks
+
 servers:
   - url: "{protocol}://rocc.org/api/v1"
     variables:
@@ -46,6 +48,7 @@ servers:
           - http
           - https
         default: https
+
 paths:
   /accounts/{login}:
     $ref: paths/accounts@{login}.yaml
@@ -114,3 +117,5 @@ components:
       $ref: components/securitySchemes/BearerAuth.yaml
     ApiKeyAuth:
       $ref: components/securitySchemes/ApiKeyAuth.yaml
+    OAuth:
+      $ref: components/securitySchemes/OAuth.yaml

--- a/openapi/paths/users.yaml
+++ b/openapi/paths/users.yaml
@@ -34,6 +34,9 @@ get:
   summary: Get all users
   description: Returns the users
   operationId: listUsers
+  security:
+    - BearerAuth: []
+    - OAuth: []
   parameters:
     - $ref: parameters/limit.yaml
     - $ref: parameters/offset.yaml


### PR DESCRIPTION
An experiment to add OAuth 2.0 authentication to the challenge registry. This mean of authentication users would enable the following features:

- Create new user account and login using OAuth providers
  - Google provider (user in PHCCP project)
  - Sage/Synapse provider
- Limit the creation of user accounts to selected organizations (e.g. `@sagebionetworks.org`), e.g. during beta testing phase